### PR TITLE
Namespaces fix

### DIFF
--- a/markdown_toolbar/markdown_toolbar.php
+++ b/markdown_toolbar/markdown_toolbar.php
@@ -6,6 +6,8 @@
  * @link https://fodor.it
  */
 
+use Shaarli\Router;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\Config\ConfigManager;
 
 /*


### PR DESCRIPTION
I found that I can't install this plugin and [ArthurHoaro/code-coloration](https://github.com/ArthurHoaro/code-coloration/) together. This PR fixes this by using appropriate namespaces.